### PR TITLE
Change location from Germany to de

### DIFF
--- a/index.md
+++ b/index.md
@@ -3,7 +3,7 @@ layout: workshop      # DON'T CHANGE THIS.
 carpentry: "swc"    # what kind of Carpentry (must be either "lc" or "dc" or "swc")
 venue: "Graduate School Life Sciences - University of Würzburg"        # brief name of host site without address (e.g., "Euphoric State University")
 address: "IMIB/RVZ, Josef-Schneider-Str. 2, Haus D15, Room 00.047, 97080 Würzburg"      # full street address of workshop (e.g., "Room A, 123 Forth Street, Blimingen, Euphoria")
-country: "Germany"      # lowercase two-letter ISO country code such as "fr" (see https://en.wikipedia.org/wiki/ISO_3166-1)
+country: "de"      # lowercase two-letter ISO country code such as "fr" (see https://en.wikipedia.org/wiki/ISO_3166-1)
 language: "en"     # lowercase two-letter ISO language code such as "fr" (see https://en.wikipedia.org/wiki/ISO_639-1)
 latlng: "49.801980,9.956515"       # decimal latitude and longitude of workshop venue (e.g., "41.7901128,-87.6007318" - use http://www.latlong.net/)
 humandate: "April 9th/10th, 2018"    # human-readable dates for the workshop (e.g., "Feb 17-18, 2020")


### PR DESCRIPTION
The template asks for the two letter code of the country so probably only ge is used if we set it to germany.
This change will hopefully fix the georgian flag issue.